### PR TITLE
Add ability to pass in options to svgicons2svgfont

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,25 @@ Despite being written from scratch, this project was inspired by the (now archiv
 - Never tested on Windows (but should work).
 - Does not generate EOT font (unecessary, woff and woff2 cover all modern browsers as well as IE9 and IE10).
 - There is no CLI, only a Node.JS API (PR welcome).
-- There is no way to pass down options to the tools used under the hood (`svgicons2svgfont`, `svg2ttf`, `ttf2woff` and `wawoff2`).
+- There is no way to pass down options to all of the tools used under the hood (`svg2ttf`, `ttf2woff` and `wawoff2`).
+- You can pass down the following options for [svgicons2svgfont](https://github.com/nfroidure/svgicons2svgfont#svgicons2svgfontoptions), :
+  - normalize: `boolean`
+  - fontHeight: `number`
 
 ## Usage
 
 ```js
 const { generateFonts } = require("@momentum-ui/webfonts-generator");
+const options = {};
 
-generateFonts("My Awesome Font", "icons/*.svg", "fonts").then(result => {
-  console.log(`Webfont ${result.fontName} created!`);
-  console.log(`WOFF file: ${result.fontFiles.woff}`);
-  console.log(`WOFF2 file: ${result.fontFiles.woff2}`);
-  console.log(`Glyphs information:`, result.glyphsData);
-});
+generateFonts("My Awesome Font", "icons/*.svg", "fonts", options).then(
+  result => {
+    console.log(`Webfont ${result.fontName} created!`);
+    console.log(`WOFF file: ${result.fontFiles.woff}`);
+    console.log(`WOFF2 file: ${result.fontFiles.woff2}`);
+    console.log(`Glyphs information:`, result.glyphsData);
+  }
+);
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Despite being written from scratch, this project was inspired by the (now archiv
 - Never tested on Windows (but should work).
 - Does not generate EOT font (unecessary, woff and woff2 cover all modern browsers as well as IE9 and IE10).
 - There is no CLI, only a Node.JS API (PR welcome).
-- There is no way to pass down options to all of the tools used under the hood (`svg2ttf`, `ttf2woff` and `wawoff2`).
+- There is no way to pass down options to some of the tools used under the hood (`svg2ttf`, `ttf2woff` and `wawoff2`).
 - You can pass down the following options for [svgicons2svgfont](https://github.com/nfroidure/svgicons2svgfont#svgicons2svgfontoptions), :
   - normalize: `boolean`
   - fontHeight: `number`

--- a/lib/fontsGenerators.js
+++ b/lib/fontsGenerators.js
@@ -8,10 +8,11 @@ const wawoff2 = require("wawoff2");
 
 const { writeFile } = require("./utils");
 
-const generateSVGFont = (iconsData, fontName, dest) => {
+const generateSVGFont = (iconsData, fontName, dest, options) => {
   const fontStream = new SVGIcons2SVGFontStream({
     fontName,
-    normalize: true,
+    fontHeight: options.fontHeight,
+    normalize: options.normalize || true,
     log() {} // Silence hints from SVGIcons2SVGFontStream
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const {
   generateWOFF2Font
 } = require("../lib/fontsGenerators");
 
-async function generateFonts(fontName, pattern, dest = "dist") {
+async function generateFonts(fontName, pattern, dest = "dist", options = {}) {
   try {
     if (!fontName) throw new Error(`A font name wasn't specified`);
 
@@ -35,7 +35,7 @@ async function generateFonts(fontName, pattern, dest = "dist") {
     const {
       buffer: svgFontBuffer,
       fileCreated: svgFile
-    } = await generateSVGFont(glyphsData, fontName, dest);
+    } = await generateSVGFont(glyphsData, fontName, dest, options);
 
     const {
       buffer: ttfFontBuffer,


### PR DESCRIPTION
When using this tool, I discovered that my fonts were distorted after generating.  Researching this I found that passing in `{normalize: true, fontHeight: 1001}` to svgicons2svgfont fixes the issue.  I added the ability to pass in an options object for those two parameters, but others could be added as well.