### PR TITLE
feat: allow specifying the timestamp of ttf file

### DIFF
--- a/lib/fontsGenerators.js
+++ b/lib/fontsGenerators.js
@@ -45,10 +45,10 @@ const generateSVGFont = (iconsData, fontName, dest, options) => {
     fontStream.end();
   });
 };
-async function generateTTFFont(svgFontBuffer, fontName, dest) {
+async function generateTTFFont(svgFontBuffer, fontName, dest, options) {
   const filename = `${fontName}.ttf`;
   const buffer = Buffer.from(
-    svg2ttf(svgFontBuffer.toString(), { familyName: fontName }).buffer
+    svg2ttf(svgFontBuffer.toString(), { familyName: fontName, ts: options.ts }).buffer
   );
   await writeFile(path.join(dest, filename), buffer);
   console.log(`${filename} written!`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/webfonts-generator",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Modern webfonts generator from SVG icons",
   "main": "src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@momentum-ui/webfonts-generator",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Modern webfonts generator from SVG icons",
   "main": "src/index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ async function generateFonts(fontName, pattern, dest = "dist", options = {}) {
     const {
       buffer: ttfFontBuffer,
       fileCreated: ttfFile
-    } = await generateTTFFont(svgFontBuffer, fontName, dest);
+    } = await generateTTFFont(svgFontBuffer, fontName, dest, options);
 
     const { fileCreated: wofffFile } = await generateWOFFFont(
       ttfFontBuffer,


### PR DESCRIPTION
It drove me nuts that every time we rebuild the icon file the font files all change even though no icons have actually changed. Tracked this down to being because the TTF file contains a timestamp. I intend to set this timestamp as the last time one of the icon svgs changed, so it will be unchanged across rebuilds.